### PR TITLE
Fix namespace bug in example of README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Sample code:
     odr::loadFile(<filename.xml>, odrData); 
     
     // pointer to the ODR data
-    odr1_5::OpenDRIVE *odrr = odrFile.OpenDRIVE1_5.get();
+    odr_1_5::OpenDRIVE *odrr = odrData.OpenDRIVE1_5.get();
    
     // access the header
     const auto header = odrr->sub_header.get();


### PR DESCRIPTION
I tried running the example code in the readme and discovered two bugs in the namespace and variable names. I have corrected them in this PR. 